### PR TITLE
[feature/signup > feature/login] [#1] 회원가입 시 Email, Nickname 검사 API 추가

### DIFF
--- a/src/main/java/kr/startoff/backend/config/CorsConfig.java
+++ b/src/main/java/kr/startoff/backend/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package kr.startoff.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+	@Bean
+	public CorsFilter corsFilter() {
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		CorsConfiguration config = new CorsConfiguration();
+		config.setAllowCredentials(true);
+		config.addAllowedOriginPattern("*");
+		config.addAllowedHeader("*");
+		config.addAllowedMethod("*");
+
+		source.registerCorsConfiguration("/api/**", config);
+		return new CorsFilter(source);
+	}
+}

--- a/src/main/java/kr/startoff/backend/controller/UserController.java
+++ b/src/main/java/kr/startoff/backend/controller/UserController.java
@@ -1,0 +1,41 @@
+package kr.startoff.backend.controller;
+
+import java.util.Optional;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.startoff.backend.service.UserService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class UserController {
+	private final UserService userService;
+
+	@GetMapping("/users/validation")
+	public ResponseEntity<?> validateDuplicationEmailOrNickname(
+		@RequestParam Optional<String> email, @RequestParam Optional<String> nickname) {
+		if (email.isPresent() && nickname.isEmpty()) {
+			if (userService.isDuplicateEmail(email.get())) {
+				return new ResponseEntity<>(HttpStatus.CONFLICT);
+			}
+			return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+		} else if (email.isEmpty() && nickname.isPresent()) {
+			if (userService.isDuplicateNickname(nickname.get())) {
+				return new ResponseEntity<>(HttpStatus.CONFLICT);
+			}
+			return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+		}
+		return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+	}
+
+}

--- a/src/main/java/kr/startoff/backend/repository/UserRepository.java
+++ b/src/main/java/kr/startoff/backend/repository/UserRepository.java
@@ -8,4 +8,8 @@ import kr.startoff.backend.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
+
+	boolean existsUserByEmail(String email);
+
+	boolean existsUserByNickname(String nickname);
 }

--- a/src/main/java/kr/startoff/backend/service/UserService.java
+++ b/src/main/java/kr/startoff/backend/service/UserService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import kr.startoff.backend.entity.User;
+import kr.startoff.backend.exception.UserNotFoundException;
 import kr.startoff.backend.model.request.SignupRequest;
 import kr.startoff.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +24,15 @@ public class UserService {
 			.password(encoder.encode(request.getPassword())).build();
 
 		return userRepository.save(user);
+	}
+
+	@Transactional(readOnly = true)
+	public boolean isDuplicateEmail(String email) {
+		return userRepository.existsUserByEmail(email);
+	}
+
+	@Transactional(readOnly = true)
+	public boolean isDuplicateNickname(String nickname) {
+		return userRepository.existsUserByNickname(nickname);
 	}
 }


### PR DESCRIPTION
- CORS를 해결하기위한 설정 구현
- UserRepository
  - Email, Nickname 중복검사 API 생성
- UserService
  - UserRepository를 거쳐서 확인하도록 구현
- UserRepository
  - Exists를 사용하여 DB에서 해당 Email과 Nickname을 가지는 User가 있는지 확인하여 boolean값 반환